### PR TITLE
gh-tools: Remove bottle: unneeded as it's deprecated

### DIFF
--- a/Formula/gh-tools.rb
+++ b/Formula/gh-tools.rb
@@ -3,7 +3,6 @@ class GhTools < Formula
   homepage "https://github.com/pmatseykanets/gh-tools"
   version "0.9.5"
   license "MIT"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.arm?


### PR DESCRIPTION
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the pmatseykanets/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/pmatseykanets/homebrew-tap/Formula/gh-tools.rb:6
```